### PR TITLE
new correction from odier@hab.de for Registre of Maillefer

### DIFF
--- a/jean_maillefer_registre/normalized_transcription-jean_maillefer.xml
+++ b/jean_maillefer_registre/normalized_transcription-jean_maillefer.xml
@@ -106,7 +106,7 @@
   <text>
       <body>
          <div type="volume">
-             <pb n="1r"/>
+<pb n="1r"/>
                <p> 
                   <add place="margin_left"> 
                      <lb/>Commencé le


### PR DESCRIPTION
Titre corrigé avec les espaces pour le pull roquets